### PR TITLE
PD-26105 - Fixed python example to correctly encode return url

### DIFF
--- a/examples/python/oauth_web_flow/app.py
+++ b/examples/python/oauth_web_flow/app.py
@@ -1,15 +1,42 @@
 from flask import Flask, session, redirect, url_for, request, render_template
 import americommerce
+from urllib.parse import urlparse, parse_qs, quote
 
 app = Flask(__name__)
 api = americommerce.ApiClient()
+
+def encode_redirect_url(redirect_uri):
+    # Parse the URL
+    parsed_uri = urlparse(redirect_uri)
+    
+    # Parse query string into dictionary
+    qs = parse_qs(parsed_uri.query, keep_blank_values=True)
+    
+    # Get the base URL without query parameters
+    base_url = f"{parsed_uri.scheme}://{parsed_uri.netloc}{parsed_uri.path}"
+    
+    # Encode only the values in the query parameters
+    if qs:
+        # For each parameter value, encode it if it's not already encoded
+        encoded_pairs = []
+        for key, values in qs.items():
+            if values:
+                # Encode the value if it contains unencoded characters
+                encoded_value = quote(values[0], safe='')
+                encoded_pairs.append(f"{key}={encoded_value}")
+        
+        query_string = "&".join(encoded_pairs)
+        return f"{base_url}?{query_string}"
+    
+    return base_url
 
 @app.route("/")
 def index():
     if not 'api_user' in session:
         r = request.base_url
         return_url = url_for('callback', r=r, _external=True)
-        return redirect(api.start_negotiation(return_url))
+        encoded_return_url = encode_redirect_url(return_url).lower()
+        return redirect(api.start_negotiation(encoded_return_url))
 
     token = session['api_user']
     page = request.args.get('page', 1, type=int)
@@ -32,7 +59,8 @@ def index():
 def callback():
     r = request.args.get('r', '')
     return_url = url_for('callback', r=r, _external=True)
-    token_data = api.verify(return_url, request.args.get('auth_id', ''), request.args.get('code', ''))
+    encoded_return_url = encode_redirect_url(return_url)
+    token_data = api.verify(encoded_return_url, request.args.get('auth_id', ''), request.args.get('code', ''))
     print(token_data)
     session['api_user'] = token_data
     return redirect(r)


### PR DESCRIPTION
Merge request for changes related to PD-26105

## Description of Changes:

Made changes to fix the Python example for OAuth Web Flow to properly encode the redirect url query parameters. Modified both initial method to get the authorization code and the method to verify the code and getting an Access Token 